### PR TITLE
fixed plane rtl

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -243,10 +243,11 @@ while 1:
             rtl_altitude = float(argv[0]) * 100
             if MODE == 'plane':
                 MAV.setParam('ALT_HOLD_RTL', rtl_altitude)
+                Script.ChangeMode("QRTL")
             else:
                 MAV.setParam('RTL_ALT', rtl_altitude)
+                Script.ChangeMode("RTL")
             
-            MAV.doCommand(MAVLink.MAV_CMD.RETURN_TO_LAUNCH,0,0,0,0,0,0,0)
             print("RTL - returning to launch")
 
         elif cmd == "LAND":


### PR DESCRIPTION
# Description

The `/rtl` endpoint for plane sets the mode to QRTL - the DoCommand we were previously using only worked for copters

Resolves #60 

## Type of change

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- RTL with plane sets mode to QRTL
- RTL with copter sets mode to RTL
- in both cases, landing is successful
