### PR TITLE
HTTP Response Codes for `/arm` and `/takeoff`

### DIFF
--- a/src/server/common/sharedobject.py
+++ b/src/server/common/sharedobject.py
@@ -27,6 +27,8 @@ class SharedObject():
         # Takeoff fields
         self._takeoffalt = 0
         self._takeoffalt_lk = Lock()
+        self._takeoff_result_flag = False
+        self._takeoff_result = 0
 
         # New home fields
         self._newhome = {}
@@ -71,8 +73,10 @@ class SharedObject():
 
         # arm/disarm fields
         self._arm_flag = False
+        self._arm_result_flag = False
         self._arm_lk = Lock()
         self._arm_status = 0
+        self._arm_result = 0
 
     def arm_set(self, status):
         self._arm_lk.acquire()
@@ -85,6 +89,22 @@ class SharedObject():
             self._arm_lk.acquire()
             ret = self._arm_status
             self._arm_flag = False
+            self._arm_lk.release()
+            return ret
+        else:
+            return None
+    
+    def arm_set_result(self, result):
+        self._arm_lk.acquire()
+        self._arm_result_flag = True
+        self._arm_result = result
+        self._arm_lk.release()
+    
+    def arm_get_result(self):
+        if self._arm_result_flag:
+            self._arm_lk.acquire()
+            ret = self._arm_result
+            self._arm_result_flag = False
             self._arm_lk.release()
             return ret
         else:
@@ -205,6 +225,22 @@ class SharedObject():
             return ret
         else:
             return 0
+        
+    def takeoff_set_result(self, result):
+        self._takeoffalt_lk.acquire()
+        self._takeoff_result_flag = True
+        self._takeoff_result = result
+        self._takeoffalt_lk.release()
+    
+    def takeoff_get_result(self):
+        if self._takeoff_result_flag:
+            self._takeoffalt_lk.acquire()
+            ret = self._takeoff_result
+            self._takeoff_result_flag = False
+            self._takeoffalt_lk.release()
+            return ret
+        else:
+            return None
     
     # New home methods
     def gcom_newhome_set(self, wp):

--- a/src/server/gcomhandler.py
+++ b/src/server/gcomhandler.py
@@ -209,7 +209,7 @@ class GCOM_Server():
             if result == 1:
                 return "Takeoff command received", 200
             else:
-                return "Takeoff unsuccessful", 418
+                return "Takeoff unsuccessful", 400
 
         @app.route("/home", methods=["POST"])
         def home():

--- a/src/server/gcomhandler.py
+++ b/src/server/gcomhandler.py
@@ -201,7 +201,15 @@ class GCOM_Server():
             print(f"Taking off to altitude {altitude}")
             self._so.gcom_takeoffalt_set(altitude)
 
-            return "Takeoff command received", 200
+            result = None 
+            while result == None:
+                result = self._so.takeoff_get_result()
+                time.sleep(0.05)
+            
+            if result == 1:
+                return "Takeoff command received", 200
+            else:
+                return "Takeoff unsuccessful", 418
 
         @app.route("/home", methods=["POST"])
         def home():
@@ -416,9 +424,18 @@ class GCOM_Server():
             if input['arm'] in [1, 0]:
                 print(f"arming {int(input['arm'])}")
                 self._so.arm_set(int(input['arm']))
-                return f"OK! {'Armed drone' if input['arm'] else 'Disarmed drone'}", 200
+
+                result = None
+                while result == None:
+                    result = self._so.arm_get_result()
+                    time.sleep(0.05)
+                
+                if result == 1:
+                    return f"OK! {'Armed drone' if input['arm'] else 'Disarmed drone'}", 200
+                else:
+                    return f"Arm/disarm failed - drone is NOT in the requested state", 418
             else:
-                return f"Unrecognized arm command", 400
+                return f"Unrecognized arm/disarm command parameter", 400
         
         #Socket stuff
         @socketio.on("connect")

--- a/src/server/mps_server.py
+++ b/src/server/mps_server.py
@@ -60,6 +60,24 @@ class MPS_Handler(socketserver.BaseRequestHandler):
             for i in range(0, wp_count):
                 print(f"{wp_list[i]._lat} {wp_list[i]._lng} {wp_list[i]._alt}")
             self.server._so.mps_currentmission_updatequeue(wp_list)
+        
+        elif data_type == "success_takeoff":
+            result = int(parameters[0])
+            if result == 1:
+                #successful takeoff
+                print("Successful takeoff")
+            else:
+                #unsuccessful
+                print("Unsuccessful takeoff")
+            self.server._so.takeoff_set_result(result)
+
+        elif data_type == "success_arm":
+            result = int(parameters[0])
+            if result == 1:
+                print("Successful arm/disarm")
+            else:
+                print("Unsuccessful arm/disarm")
+            self.server._so.arm_set_result(result)
     
     def next_instruction(self, current_wpn):
         # Place new instructions onto the queue


### PR DESCRIPTION
# Description

Now that #61 is complete, we can implement the ability to signal to callers whether their `/arm` and `/takeoff` calls were successful thru HTTP status codes. 

Before, we'd return 200 whether the command was effective or not and the caller would have to confirm the command took effect. Now we use HTTP status codes to indicate to the caller of the commands were unsuccessful.

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- Successful arm and successful disarm
- Unsuccessful arm while disarmed
- Attempting to takeoff while armed/disarmed

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
