### PR TITLE
Cleanup and Specification Review

### DIFF
--- a/api_spec.yml
+++ b/api_spec.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: MissionPlanner Scripts
-  version: 1.4.1
+  version: 2.0.0
   description: "This is the API that the MissionPlanner Scripts server exposes to GCOM."
   contact:
     name: Amin Fahiminia, Hansen Dan
@@ -9,27 +9,30 @@ servers:
   - url: http://localhost:9000
 tags:
   - name: queue
-    description: Access to aircraft waypoint queue
+    description: Access to the waypoint queue
   - name: status
-    description: Current aircraft status
-  - name: lock
-    description: Toggle queue-based movement
+    description: Access to aircraft status
   - name: takeoff
-    description: Take off after motors are armed
+    description: Access to takeoff and arming motors
   - name: landing
-    description: Landing, RTL, and setting Home
+    description: Access to landing, RTL, and home waypoint
   - name: options
-    description: Configure flight options
+    description: Access to flight options
 paths:
+  /:
+    get:
+      summary: Call this to see if the server's running.
+      responses:
+        "200":
+          description: server is running
   /queue:
     get:
       tags:
         - queue
-      summary: Returns the current list of waypoints in the queue
+      summary: Returns the current list of waypoints remaining in the queue
       description: >-
-        Returns the current list of waypoints in the queue, in the order of their names. 
+        Returns the current list of queue of waypoints to hit. 
         Waypoints that have been passed and removed from the queue are not displayed.
-      operationId: api.queue_get
       responses:
         "200":
           description: successful operation
@@ -45,13 +48,13 @@ paths:
       summary: Overwrite the queue with a new list of waypoints 
       description: >-
         POST request containing a list of waypoints with names and longitude, 
-        latitude, and altitude values. If altitude is nil, carry on with the 
-        same altitude as you had last waypoint.
-        Previous queue should be overwritten if there is already one in place.
+        latitude, and altitude values. If the altitude for a waypoint is null, 
+        uses the altitude of the previous waypoint (in the case of the first 
+        waypoint, uses the current altitude of the drone).
+        The existing waypoint queue will be overwritten and lost.
         Longitude, name, and latitude must not be null/empty. Returns a Bad 
         Request status code and error message in that case. Longitude and 
         latitude in degrees, altitude in meters.
-      operationId: api.queue_post
       requestBody:
         $ref: "#/components/requestBodies/Queue"
       responses:
@@ -59,6 +62,36 @@ paths:
           description: successful operation
         "400":
           description: bad request
+  /prepend:
+    post:
+      tags:
+       - queue
+      summary: Insert a waypoint onto the front of the queue.
+      responses:
+        "200":
+          description: successful operation
+        "400":
+          description: bad request
+  /append:
+    post:
+      tags:
+       - queue
+      summary: Insert a waypoint onto the back of the queue.
+      responses:
+        "200":
+          description: successful operation
+        "400":
+          description: bad request
+  /clear:
+    get:
+      tags:
+        - queue
+      summary: Clear the waypoint queue. 
+      description: >-
+        Idempotent with POST'ing an empty queue to /queue.
+      responses:
+        "200":
+          description: Queue successfully emptied.
   /status:
     get:
       tags:
@@ -68,7 +101,6 @@ paths:
         GET request returns the aircraft status. Velocity in m/s. Altitude 
         in meters and is relative to sea level. Longitude, latitude, heading 
         in degrees.
-      operationId: api.status_get
       responses:
         "200":
           description: Successful operation
@@ -76,45 +108,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Status"
-  /lock:
-    get:
-      tags:
-        - lock
-      summary: Prevent the aircraft from moving based on the queue
-      description: >-
-        Stops the aircraft from moving based on the Mission Planner Scripts' 
-        waypoint queue loading functionality, maintaining the queue internally. 
-        Return Bad Request if the aircraft is already locked, or the queue is empty.
-      operationId: api.lock_get
-      responses:
-        "200":
-          description: Successful operation
-        "400":
-          description: Aircraft already locked or queue empty
-  /unlock:
-    get:
-      tags:
-        - lock
-      summary: Resume aircraft movement based on the queue
-      description: >-
-        Resume moving the aircraft based on the currently stored queue. 
-        Returns a Bad Request status code and an error message if the aircraft 
-        is already unlocked.
-      operationId: api.unlock_get
-      responses:
-        "200":
-          description: Successful operation
-        "400":
-          description: Aircraft already unlocked
   /takeoff:
     post:
       tags:
         - takeoff
       summary: Lift off to a given altitude
       description: >-
-        POST request containing an altitude to take off to that is measured 
-        relative to sea level. Don't put an altitude that would be underground.
-      operationId: api.takeoff_post
+        POST request containing an altitude to take off to.
+        Don't put an altitude that would be underground.
       requestBody:
         required: true
         content:
@@ -139,12 +140,36 @@ paths:
         Aircraft returns to home waypoint and lands (return-to-launch). 
         Returns a Bad Request status code and error message if the drone 
         could not execute the operation.
-      operationId: api.rtl_get
       responses:
         "200":
           description: Successful, drone has initiated RTL procedure
         "400":
-          description: Initiating RTL unsuccessful
+          description: Could not initiate RTL
+    post:
+      tags:
+        - landing
+      summary: return to launch at specified altitude
+      description: >-
+        Aircraft returns to home waypoint and lands (return-to-launch). 
+        Returns a Bad Request status code and error message if the drone 
+        could not execute the operation.
+        POST request body contains the altitude the drone should be at 
+        while transiting back towards the launch point.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                altitude:
+                  type: number
+                  format: float64
+      responses:
+        "200":
+          description: Successful, drone has initiated RTL procedure
+        "400":
+          description: Could not initiate RTL
   /land:
     get:
       tags:
@@ -154,19 +179,17 @@ paths:
         Aircraft stops at its current position and lands. 
         Returns a Bad Request status code and error message if the drone 
         could not execute the operation.
-      operationId: api.land_get
       responses:
         "200":
           description: Successful, drone has started landing procedure
         "400":
-          description: Initiating landing unsuccessful
+          description: Could not initiate landing
     post: 
       tags: 
         - landing 
       summary: land at designated location (VTOL-compatible)
       description: >-
         VTOL compatible land at the location in the request.
-      operationId: api.land_post 
       requestBody:
         content:
           application/json:
@@ -175,6 +198,8 @@ paths:
       responses:
         "200":
           description: Successful, drone has started landing procedure 
+        "400":
+          description: Invalid coordinates - latitude and/or longitude value was null 
   /home:
     post:
       tags:
@@ -184,7 +209,6 @@ paths:
         POST request containing a waypoint whose longitude, latitiude and 
         altitiude will be the basis for the new home waypoint. All other 
         fields will be ignored.
-      operationId: api.home_post
       requestBody:
         content:
           application/json:
@@ -203,8 +227,7 @@ paths:
       description: >-
         Returns the current flight mode of the aircraft. The values 
         correspond to those in the MAV commands, so 3 indicates VTOL flight 
-        while 4 indicates fixed wing flight. 
-      operationId: api.vtol_transition_get
+        while 4 indicates fixed wing flight.
       responses:
         "200":
           description: Returned flight mode 
@@ -224,7 +247,6 @@ paths:
         specified by the mode property in the request body. As in 
         the GET endpoint, use 3 to indicate VTOL and 4 to indicate 
         fixed wing.
-      operationId: api.vtol_transition_post
       requestBody:
         content:
           application/json: 
@@ -236,6 +258,8 @@ paths:
       responses:
         "200": 
           description: Flight mode changed
+        "400":
+          description: Invalid flight mode
   /diversion:
     post: 
       tags: 
@@ -248,7 +272,6 @@ paths:
         process the information, produce a diverted path, and pass 
         that to the aircraft, returning 200. Note that 200 will be 
         returned whether or not the new path is applied or not.
-      operationId: api.diversion_post
       requestBody:
         content:
           application/json:
@@ -271,7 +294,6 @@ paths:
       summary: Change flight mode of the aircraft
       description: >-
         Set the flight mode of the aircraft to Loiter, Stabilize, Auto, or Guided
-      operationId: api.mode_put
       requestBody:
         content:
           application/json:
@@ -286,33 +308,32 @@ paths:
           description: Operation processed
         "400":
           description: Unrecognized mode
-  /invoke:
-    post:
+  /arm:
+    put:
       tags:
-        - options
-      summary: Invoke as specified in post request
-      description: >-
-        Performs a crucial functionality
-      operationId: api.invoke_post
+        - takeoff
+      summary: Arm or disarm the motors. Take care.
       requestBody:
         content:
           application/json:
-            schema: 
-              type: object 
+            schema:
+              type: object
               properties:
-                message:
-                  type: string
+                arm:
+                  type: integer
+                  enum: [0, 1]
       responses:
         "200":
-          description: "Important invokation is underway"
+          description: Arm/disarm successful.
+        "400":
+          description: Arm/disarm failed - drone is NOT in the requested state
   /altstandard:
     put:
       tags:
         - options
-      summary: TODO
+      summary: UNIMPLEMENTED
       description: >-
-        TODO
-      operationId: api.altstandard_put
+        UNIMPLEMENTED
       requestBody:
         content:
           application/json:
@@ -323,10 +344,8 @@ paths:
                   type: string
                   enum: ['AGL', 'MSL']
       responses:
-        "200":
-          description: OK
-        "400":
-          description: Unrecognized standard
+        "410":
+          description: "UNIMPLEMENTED"
 components:
   requestBodies:
     Queue:
@@ -363,13 +382,16 @@ components:
     Status:
       type: object
       properties:
-        velocity:
+        airspeed:
           type: number
           format: float64
-        longitude:
+        groundspeed:
           type: number
           format: float64
         latitude:
+          type: number
+          format: float64
+        longitude:
           type: number
           format: float64
         altitude:
@@ -381,5 +403,17 @@ components:
         batteryvoltage:
           type: number
           format: float64
+        winddirection:
+          type: number
+          format: float64
+        windvelocity:
+          type: number
+          format: float64
+        current_wpn:
+          type: integer
+        date:
+          type: integer
+        time:
+          type: integer
       xml:
         name: Status

--- a/spec.postman_collection.json
+++ b/spec.postman_collection.json
@@ -372,7 +372,7 @@
 			]
 		},
 		{
-			"name": "insert",
+			"name": "prepend",
 			"item": [
 				{
 					"name": "Insert waypoint at beginning of queue",
@@ -389,12 +389,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{ base_url }}/insert",
+							"raw": "{{ base_url }}/prepend",
 							"host": [
 								"{{ base_url }}"
 							],
 							"path": [
-								"insert"
+								"prepend"
 							]
 						}
 					},
@@ -408,7 +408,7 @@
 				{
 					"name": "Arm or Disarm the Drone",
 					"request": {
-						"method": "POST",
+						"method": "PUT",
 						"header": [],
 						"body": {
 							"mode": "raw",

--- a/spec.postman_collection.json
+++ b/spec.postman_collection.json
@@ -131,28 +131,6 @@
 			]
 		},
 		{
-			"name": "unlock",
-			"item": [
-				{
-					"name": "Resume aircraft movement based on the queue",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ base_url }}/unlock",
-							"host": [
-								"{{ base_url }}"
-							],
-							"path": [
-								"unlock"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
 			"name": "takeoff",
 			"item": [
 				{
@@ -176,28 +154,6 @@
 							],
 							"path": [
 								"takeoff"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "lock",
-			"item": [
-				{
-					"name": "Prevent the aircraft from moving based on the queue",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{ base_url }}/lock",
-							"host": [
-								"{{ base_url }}"
-							],
-							"path": [
-								"lock"
 							]
 						}
 					},
@@ -333,37 +289,6 @@
 							],
 							"path": [
 								"flightmode"
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "invoke",
-			"item": [
-				{
-					"name": "Use Text-To-Speech",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"message\": \"Hello world\"\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{ base_url }}/invoke",
-							"host": [
-								"{{ base_url }}"
-							],
-							"path": [
-								"invoke"
 							]
 						}
 					},

--- a/src/client.py
+++ b/src/client.py
@@ -123,12 +123,12 @@ while 1:
         print("Entered Manual Mode")
         break
     else:
-        if cmd == "NEWM":
+        if cmd == "NEW_MISSION":
             #Enter guided and await new mission waypoints
             Script.ChangeMode("Guided")
             wp_array = []
             upcoming_mission = True
-            print("NEWM - About to recieve new mission")
+            print("NEW_MISSION - About to recieve new mission")
 
         elif cmd == "NEXT":
             upcoming_mission = False
@@ -142,7 +142,7 @@ while 1:
                 float_alt = float(argv[3 * idx + 2])
 
                 wp_array.append((float_lat, float_lng, float_alt))
-                print("NEXT - received waypoint {:} {:} {:}".format(float_lat, float_lng, float_alt))
+                print("received waypoint {:} {:} {:}".format(float_lat, float_lng, float_alt))
             
             #set mission
             upload_mission(wp_array)
@@ -177,7 +177,7 @@ while 1:
             #print("IDLE")
             pass
 
-        elif cmd == "TOFF":
+        elif cmd == "TAKEOFF":
             if (len(argv) == 1):
                 takeoffalt = float(argv[0])
                 Script.ChangeMode("Loiter")
@@ -201,15 +201,15 @@ while 1:
                 if cs.armed:
                     Script.ChangeMode("Auto")
                     MAV.doCommand(MAVLink.MAV_CMD.MISSION_START,0,0,0,0,0,0,0) # Arm motors
-                    print("TOFF - takeoff to {:}m".format(takeoffalt))
+                    print("TAKEOFF - takeoff to {:}m".format(takeoffalt))
 
                     rsock.sendto(bytes("success_takeoff 1", 'utf-8'), (HOST, RPORT))
                 else:
-                    print("TOFF - ERROR, DRONE NOT ARMED")
+                    print("TAKEOFF - ERROR, DRONE NOT ARMED")
 
                     rsock.sendto(bytes("success_takeoff 0", 'utf-8'), (HOST, RPORT))
             else:
-                print("TOFF - invalid command")
+                print("TAKEOFF - invalid command")
 
                 rsock.sendto(bytes("success_takeoff 0", 'utf-8'), (HOST, RPORT))
 
@@ -248,7 +248,7 @@ while 1:
             MAV.doCommand(MAVLink.MAV_CMD.LAND,0,0,0,0,cs.lat,cs.lng,0)
             print("LAND - landing in place")
         
-        elif cmd == "VTOLLAND":
+        elif cmd == "VTOL_LAND":
             landlat = float(argv[0])
             landlng = float(argv[1])
 
@@ -270,18 +270,18 @@ while 1:
             MAV.setWPACK()
             Script.ChangeMode("Auto")
             # MAV.doCommand(MAVLink.MAV_CMD.LAND,0,0,0,0,cs.lat,cs.lng,0)
-            print("LAND - landing at {:}, {:}".format(landlat, landlng))
+            print("VTOL_LAND - landing at {:}, {:}".format(landlat, landlng))
         
         elif cmd == "MODE":
             MAV.doCommand(MAVLink.MAV_CMD.DO_VTOL_TRANSITION,int(argv[0]),0,0,0,0,0,0)
         
-        elif cmd == "FMDE":
+        elif cmd == "FLIGHT_MODE":
             if MODE == 'plane' and argv[0] in ['loiter', 'stabilize']:
                 Script.ChangeMode("q{:}".format(argv[0]))
             else:
                 Script.ChangeMode(argv[0])
 
-        elif cmd == "QGET":
+        elif cmd == "QUEUE_GET":
             #get info
             numwp = MAV.getWPCount()
             wplist = []

--- a/src/client.py
+++ b/src/client.py
@@ -176,17 +176,6 @@ while 1:
             # IDLE - do nothing
             #print("IDLE")
             pass
-        elif cmd == "LOCK":
-            # LOCK - lock/unlock the UAV
-            flag = int(argv[0])
-            if flag:
-                #lock the UAV
-                Script.ChangeMode("Guided")
-                print("LOCK - locked the UAV")
-            else:
-                #unlock the UAV
-                Script.ChangeMode("Auto")
-                print("LOCK - unlocked the UAV")
 
         elif cmd == "TOFF":
             if (len(argv) == 1):

--- a/src/server/common/sharedobject.py
+++ b/src/server/common/sharedobject.py
@@ -20,10 +20,6 @@ class SharedObject():
         self._status = ()
         self._status_lk = Lock()
 
-        # Lock fields
-        self._locked = False 
-        self._locked_lk = Lock()
-
         # Takeoff fields
         self._takeoffalt = 0
         self._takeoffalt_lk = Lock()
@@ -193,23 +189,6 @@ class SharedObject():
         self._status_lk.release()
         return ret
 
-    # Lock methods
-    def gcom_locked_set(self, locked):
-        ret = True
-        self._locked_lk.acquire()
-        if self._locked == locked:
-            ret = False
-        self._locked = locked 
-        self._locked_lk.release()
-        return ret
-    
-    def mps_locked_get(self):
-        ret = True 
-        self._locked_lk.acquire()
-        ret = self._locked 
-        self._locked_lk.release()
-        return ret
-
     # takeoff methods
     def gcom_takeoffalt_set(self, alt):
         self._takeoffalt_lk.acquire()
@@ -317,21 +296,6 @@ class SharedObject():
         self._vtol_lk.acquire()
         ret = self._vtol_mode
         self._vtol_lk.release()
-        return ret
-
-    # voice methods
-    def voice_set(self, text):
-        self._voice_lk.acquire()
-        self._voice_flag = True
-        self._voice_text = text
-        self._voice_lk.release()
-
-    def voice_get(self):
-        self._voice_lk.acquire()
-        ret = self._voice_text
-        self._voice_text = ""
-        self._voice_flag = False
-        self._voice_lk.release()
         return ret
     
     # flightmode methods

--- a/src/server/gcomhandler.py
+++ b/src/server/gcomhandler.py
@@ -65,31 +65,6 @@ class GCOM_Server():
 
             return retJSON
 
-        @app.route("/lock", methods=["GET"])
-        def lock():
-            status = self._so.gcom_locked_set(True)
-            if status:
-                print("Locked by GCOM")
-                return "Mission Queue Locked", 200
-
-            else:
-                print("Lock failed")
-
-                return "Mission Queue Lock Error: Already Locked", 400
-
-
-        @app.route("/unlock", methods=["GET"])
-        def unlock():
-            status = self._so.gcom_locked_set(False)
-            if status:
-                print("unlocked by GCOM")
-
-                return "Mission Queue unlocked", 200
-            else:
-                print("Unlock failed")
-
-                return "Mission Queue Unlock Error: Already Unlocked", 400
-
         @app.route("/land", methods=["GET"])
         def land():
             print("Landing")
@@ -100,12 +75,12 @@ class GCOM_Server():
 
         @app.route("/rtl", methods=["GET", "POST"])
         def rtl():
-            altitude = request.get_json().get('altitude', 5)
+            altitude = request.get_json().get('altitude', 50)
 
             print(f"RTL at {altitude}")
             self._so.gcom_rtl_set(altitude)
 
-            return "Returning to Land", 200
+            return "Returning to Launch", 200
 
         # VTOL LAND ENDPOINT
 
@@ -144,7 +119,7 @@ class GCOM_Server():
 
             return "ok", 200
         
-        @app.route("/insert", methods=['POST'])
+        @app.route("/prepend", methods=['POST'])
         def insert_wp():
             payload = request.get_json()
 
@@ -396,11 +371,6 @@ class GCOM_Server():
             self._so.gcom_locked_set(False)
             return "diverting"
         
-        #end of endpoints
-        @app.route("/invoke", methods=["POST"])
-        def invoke():
-            return f"Deprecated endpoint. Nothing happened", 410
-        
         @app.route("/flightmode", methods=["PUT"])
         def change_flight_mode():
             input = request.get_json()
@@ -415,7 +385,7 @@ class GCOM_Server():
             else:
                 return f"Unrecognized mode: {input['mode']}", 400
         
-        @app.route("/arm", methods=["POST"])
+        @app.route("/arm", methods=["PUT"])
         def arm_disarm_drone():
             input = request.get_json()
 
@@ -434,6 +404,11 @@ class GCOM_Server():
                     return f"Arm/disarm failed - drone is NOT in the requested state", 418
             else:
                 return f"Unrecognized arm/disarm command parameter", 400
+        
+        @app.route("/altstandard", methods=["PUT"])
+        def altstandard():
+            #Call into altitude_standard_set
+            return "UNIMPLMENTED", 410
         
         #Socket stuff
         @socketio.on("connect")

--- a/src/server/mps_server.py
+++ b/src/server/mps_server.py
@@ -15,6 +15,19 @@ class MPS_Handler(socketserver.BaseRequestHandler):
     """
 
     def handle(self):
+        """
+        Handles one 'cycle' of MPS -> client communications.
+        Performs different actions based on the recieved datatype:
+            telemetry:  This is the main 'back and forth' between the client and MPS.
+                        Here, we receive an update from the client with the latest drone telemetry.
+                        In turn, MPS responds with the next instruction indicating what the drone
+                        should do this cycle.
+
+            queue:      This is data about the current queue as it is in MissionPlanner. 
+
+            success_takeoff, success_arm: Indicates whether a takeoff or arm command was successful. 
+        """
+
         data = self.request[0].strip().decode()
         socket = self.request[1]
 
@@ -80,7 +93,25 @@ class MPS_Handler(socketserver.BaseRequestHandler):
             self.server._so.arm_set_result(result)
     
     def next_instruction(self, current_wpn):
-        # Place new instructions onto the queue
+        """Returns the next instruction to be sent to the drone."""
+        
+        self.check_shared_object(current_wpn)
+
+        # Retrieve an instruction
+        if (self.server._instructions.empty()):
+            return b"IDLE"
+        else:
+            instruction = self.server._instructions.pop()
+            if (type(instruction) != bytes):
+                print("instruction", instruction)
+                return bytes(instruction, "utf-8")
+            else:
+                print(f"packed bytes: length {len(instruction)}",)
+            return instruction
+    
+    def check_shared_object(self, current_wpn):
+        """Check shared object for new directives, and place instructions on the queue if necessary."""
+
         instruction = ""
 
         # Check if we should send back updated mission queue
@@ -92,14 +123,10 @@ class MPS_Handler(socketserver.BaseRequestHandler):
         if newmode != "":
             self.server._instructions.push(f"CONFIG {newmode}")
         
+        # Check if we should change our altitude standard
         altitude_standard = self.server._so.altitude_standard_get()
         if altitude_standard != "":
             self.server._instructions.push(f"ALTSTD {altitude_standard}")
-        
-        arm = self.server._so.arm_get()
-        if arm is not None:
-            print("ARMING...")
-            self.server._instructions.push(f"ARM {arm}")
 
         # Check if there is a new home
         newhome = self.server._so.mps_newhome_get()
@@ -107,6 +134,7 @@ class MPS_Handler(socketserver.BaseRequestHandler):
             wp = Waypoint(newhome['id'], newhome['name'], newhome['latitude'], newhome['longitude'], newhome['altitude'])
             self.server._instructions.push(f"HOME {str(wp)}")
 
+        # Check if we need to land
         vtol_land = self.server._so.mps_vtol_land_get()
         if vtol_land != None:
             wp = Waypoint(vtol_land['id'], vtol_land['name'], vtol_land['latitude'], vtol_land['longitude'], vtol_land['altitude'])
@@ -129,81 +157,53 @@ class MPS_Handler(socketserver.BaseRequestHandler):
         elif self.server._so.mps_vtol_get() != self.server._flight_mode:
             self.server._flight_mode = self.server._so.mps_vtol_get()
             self.server._instructions.push(f"MODE {self.server._flight_mode}")
-        
-        # Check if we should send tts text
-        elif self.server._so._voice_flag:
-            text = self.server._so.voice_get()
-            self.server._instructions.push(f"TTS {text}")
 
         # Check if we should switch modes
         elif self.server._so._flightmode_flag:
             mode = self.server._so.flightmode_get()
             self.server._instructions.push(f"FMDE {mode}")
-
-        # Check if we should lock
-        elif self.server._so.mps_locked_get():
-            print("Locking...")
-            if self.server._locked:
-                # Still locked, idle
-                #self.server._instructions.push("IDLE")
-                pass
-            else:
-                # Send the lock instruction
-                self.server._instructions.push("LOCK 1")
-                self.server._locked = True
-        else:
-            # reset _locked if coming out of locked state
-            if self.server._locked:
-                self.server._instructions.push("LOCK 0")
-                self.server._locked = False
+        
+        # Check if we should arm/disarm the motors
+        arm = self.server._so.arm_get()
+        if arm is not None:
+            print("ARMING...")
+            self.server._instructions.push(f"ARM {arm}")
             
-            # Check for a new waypoint to push
-            push_wp = self.server._so.append_wp_get()
-            if push_wp:
-                self.server._instructions.push(f"PUSH {str(push_wp)}")
+        # Check for a new waypoint to push
+        push_wp = self.server._so.append_wp_get()
+        if push_wp:
+            self.server._instructions.push(f"PUSH {str(push_wp)}")
 
-            # Check for a new mission
-            nextwpq = self.server._so.mps_newmission_get()
-            if nextwpq != None:
-                # Overwrite the current mission with the new one
-                print("New mission found!")
-                self.server._current_mission = Mission(nextwpq)
-                
-                # Place instruction for the new mission onto the queue
-                self.server._instructions.push("NEWM")
+        # Check for a new mission
+        nextwpq = self.server._so.mps_newmission_get()
+        if nextwpq != None:
+            # Overwrite the current mission with the new one
+            print("New mission found!")
+            self.server._current_mission = Mission(nextwpq)
+            
+            # Place instruction for the new mission onto the queue
+            self.server._instructions.push("NEWM")
 
-                #Prepare packed mission
-                missionbytes = b""
+            #Prepare packed mission
+            missionbytes = b""
 
-                self.server._newmc = 1
-                while (not nextwpq.empty()):
-                    curr = nextwpq.pop()
-                    self.server._newmc += 1
-                    missionbytes += bytes(struct.pack("f", curr._lat))
-                    missionbytes += bytes(struct.pack("f", curr._lng))
-                    missionbytes += bytes(struct.pack("f", curr._alt))
+            self.server._newmc = 1
+            while (not nextwpq.empty()):
+                curr = nextwpq.pop()
+                self.server._newmc += 1
+                missionbytes += bytes(struct.pack("f", curr._lat))
+                missionbytes += bytes(struct.pack("f", curr._lng))
+                missionbytes += bytes(struct.pack("f", curr._alt))
 
-                self.server._instructions.push(missionbytes)
-            else:
-                # Keep going and send current wpno to shared obj
-                if (self.server._newmc == 0):
-                    self.server._so.mps_currentmission_update(current_wpn)
-                else:
-                    self.server._newmc -= 1
-                #self.server._instructions.push("CONT")
-                pass
-
-        # Retrieve an instruction
-        if (self.server._instructions.empty()):
-            return b"IDLE"
+            self.server._instructions.push(missionbytes)
         else:
-            instruction = self.server._instructions.pop()
-            if (type(instruction) != bytes):
-                print("instruction", instruction)
-                return bytes(instruction, "utf-8")
+            # Keep going and send current wpno to shared obj
+            if (self.server._newmc == 0):
+                self.server._so.mps_currentmission_update(current_wpn)
             else:
-                print(f"packed bytes: length {len(instruction)}",)
-            return instruction
+                self.server._newmc -= 1
+            #self.server._instructions.push("CONT")
+            pass
             
 
 class MPS_Internal_Server(socketserver.UDPServer):
@@ -213,7 +213,6 @@ class MPS_Internal_Server(socketserver.UDPServer):
         self._current_mission = Mission() # Empty mission
         self._instructions = Queue()
 
-        self._locked = False
         self._newmc = 0
         self._flight_mode = 3
 

--- a/src/server/mps_server.py
+++ b/src/server/mps_server.py
@@ -116,7 +116,7 @@ class MPS_Handler(socketserver.BaseRequestHandler):
 
         # Check if we should send back updated mission queue
         if self.server._so.mps_currentmission_shouldupdate():
-            self.server._instructions.push(f"QGET")
+            self.server._instructions.push(f"QUEUE_GET")
 
         # Check if there is a flight config update request
         newmode = self.server._so.flightConfig_get()
@@ -138,12 +138,12 @@ class MPS_Handler(socketserver.BaseRequestHandler):
         vtol_land = self.server._so.mps_vtol_land_get()
         if vtol_land != None:
             wp = Waypoint(vtol_land['id'], vtol_land['name'], vtol_land['latitude'], vtol_land['longitude'], vtol_land['altitude'])
-            self.server._instructions.push(f"VTOLLAND {str(wp)}")
+            self.server._instructions.push(f"VTOL_LAND {str(wp)}")
 
         # Check takeoff altitude
         takeoffalt = self.server._so.mps_takeoffalt_get()
         if takeoffalt != 0:
-            self.server._instructions.push(f"TOFF {takeoffalt}")
+            self.server._instructions.push(f"TAKEOFF {takeoffalt}")
 
         # Check if we should rtl
         elif self.server._so._rtl_flag:
@@ -161,7 +161,7 @@ class MPS_Handler(socketserver.BaseRequestHandler):
         # Check if we should switch modes
         elif self.server._so._flightmode_flag:
             mode = self.server._so.flightmode_get()
-            self.server._instructions.push(f"FMDE {mode}")
+            self.server._instructions.push(f"FLIGHT_MODE {mode}")
         
         # Check if we should arm/disarm the motors
         arm = self.server._so.arm_get()
@@ -182,7 +182,7 @@ class MPS_Handler(socketserver.BaseRequestHandler):
             self.server._current_mission = Mission(nextwpq)
             
             # Place instruction for the new mission onto the queue
-            self.server._instructions.push("NEWM")
+            self.server._instructions.push("NEW_MISSION")
 
             #Prepare packed mission
             missionbytes = b""


### PR DESCRIPTION
# Description

- The API spec now reflects the numerous updates we've made, including all the new methods we've added since the last time we updated the spec. 
- `/lock`, `/unlock`, and `/invoke` were deprecated, `/arm` was changed from `POST` to `PUT`, and `/insert` was renamed to `/prepend`. 

### Notes
- `/land` and `/diversion` could possibly be deprecated as well.
- We need to double-check the Postman collection(s)
- The scope of the changes made to the code itself weren't that extensive, but we should retest every method to be safe and to double-check compliance with the new spec.

Marking as Draft until testing complete
Resolves #54 
